### PR TITLE
Fix build error on mac_mini

### DIFF
--- a/cmvs_catkin/include/stann/dpoint.hpp
+++ b/cmvs_catkin/include/stann/dpoint.hpp
@@ -489,7 +489,7 @@ operator>>(std::istream& is,dpoint<NumType,D> &p)
 		 if(!(is >> p[i])){
 			 if(!is.eof()){
 			   std::cerr << "Error Reading Point:" 
-				     << is << std::endl;
+				     << is.rdbuf() << std::endl;
 				exit(1);
 			 }
 		 }


### PR DESCRIPTION
This should fix this error on mac_mini:

```
/Users/slynen/workspace/subtree_multiagent_mapping/src/dependencies/thirdparty_submodules/cmvs_pmvs_catkin/cmvs_catkin/include/stann/dpoint.hpp:492:10: error: invalid operands to binary expression ('basic_ostream<char, std::__1::char_traits<char> >' and 'std::istream' (aka 'basic_istream<char>'))
         << is << std::endl;
         ^  ~~
```
