### PR TITLE
Read images with index offset

### DIFF
--- a/cmvs_catkin/include/cmvs/bundle.h
+++ b/cmvs_catkin/include/cmvs/bundle.h
@@ -65,12 +65,13 @@ class Cbundle {
   void run(const std::string prefix, const int imageThreshold,
            const int tau, const float scoreRatioThreshold,
            const float coverageThreshold, const int pnumThreshold,
-           const int CPU);
+           const int CPU, const unsigned int cnumOffset = 0u);
   // root dir
   std::string m_prefix;
 
   // # of cameras
   int m_cnum;
+  unsigned int m_cnumOffset;
   // # of points
   int m_pnum;
   
@@ -109,7 +110,7 @@ class Cbundle {
   void prep(const std::string prefix, const int imageThreshold,
             const int tau, const float scoreRatioThreshold,
             const float coverageThreshold, const int pnumThreshold,
-            const int CPU);
+            const int CPU, const unsigned int cnumOffset);
 
   void prep2(void);
   

--- a/cmvs_catkin/include/cmvs/bundle.h
+++ b/cmvs_catkin/include/cmvs/bundle.h
@@ -63,8 +63,8 @@ class Cbundle {
   virtual ~Cbundle();
   
   void run(const std::string prefix, const int imageThreshold, const int tau,
-           const float scoreRatioThreshold, const float coverageThreshold,
-           const int pnumThreshold, const int CPU);
+             const float scoreRatioThreshold, const float coverageThreshold,
+             const int pnumThreshold, const int CPU, const unsigned int cnumOffset);
 
   void run(const std::string prefix, const int imageThreshold, const int tau,
            const float scoreRatioThreshold, const float coverageThreshold,

--- a/cmvs_catkin/include/cmvs/bundle.h
+++ b/cmvs_catkin/include/cmvs/bundle.h
@@ -62,10 +62,14 @@ class Cbundle {
   Cbundle(void);
   virtual ~Cbundle();
   
-  void run(const std::string prefix, const int imageThreshold,
-           const int tau, const float scoreRatioThreshold,
-           const float coverageThreshold, const int pnumThreshold,
-           const int CPU, const unsigned int cnumOffset = 0u);
+  void run(const std::string prefix, const int imageThreshold, const int tau,
+           const float scoreRatioThreshold, const float coverageThreshold,
+           const int pnumThreshold, const int CPU);
+
+  void run(const std::string prefix, const int imageThreshold, const int tau,
+           const float scoreRatioThreshold, const float coverageThreshold,
+           const int pnumThreshold, const int CPU);
+
   // root dir
   std::string m_prefix;
 

--- a/cmvs_catkin/src/cmvs/bundle.cc
+++ b/cmvs_catkin/src/cmvs/bundle.cc
@@ -126,6 +126,14 @@ void Cbundle::prep2(void) {
 void Cbundle::run(const std::string prefix, const int imageThreshold,
                   const int tau, const float scoreRatioThreshold,
                   const float coverageThreshold,
+                  const int pnumThreshold, const int CPU) {
+  const unsigned int no_offset = 0u;
+  run(prefix, imageThreshold, tau, scoreRatioThreshold, coverageThreshold, pnumThreshold, CPU, no_offset);
+}
+
+void Cbundle::run(const std::string prefix, const int imageThreshold,
+                  const int tau, const float scoreRatioThreshold,
+                  const float coverageThreshold,
                   const int pnumThreshold, const int CPU, const unsigned int cnumOffset) {
   startTimer();
   

--- a/cmvs_catkin/src/cmvs/bundle.cc
+++ b/cmvs_catkin/src/cmvs/bundle.cc
@@ -37,12 +37,13 @@ Cbundle::~Cbundle() {
 void Cbundle::prep(const std::string prefix, const int imageThreshold,
                    const int tau, const float scoreRatioThreshold,
                    const float coverageThreshold,
-                   const int pnumThreshold, const int CPU) {
+                   const int pnumThreshold, const int CPU, const unsigned int cnumOffset) {
   if (pnumThreshold != 0) {
     cerr << "Should use pnumThreshold = 0" << endl;
     exit (1);
   }
   
+  m_cnumOffset = cnumOffset;
   m_prefix = prefix;
   m_imageThreshold = imageThreshold;
   m_tau = tau;
@@ -68,7 +69,7 @@ void Cbundle::prep(const std::string prefix, const int imageThreshold,
 
   m_dlevel = 7;
   m_maxLevel = 12;
-  m_pss.init(images, prefix, m_maxLevel + 1, 5, 0);
+  m_pss.init(images, prefix, m_maxLevel + 1, 5, 0, cnumOffset);
   
   cerr << "Set widths/heights..." << flush;
   setWidthsHeightsLevels();
@@ -125,11 +126,11 @@ void Cbundle::prep2(void) {
 void Cbundle::run(const std::string prefix, const int imageThreshold,
                   const int tau, const float scoreRatioThreshold,
                   const float coverageThreshold,
-                  const int pnumThreshold, const int CPU) {
+                  const int pnumThreshold, const int CPU, const unsigned int cnumOffset) {
   startTimer();
   
   prep(prefix, imageThreshold, tau, scoreRatioThreshold,
-       coverageThreshold, pnumThreshold, CPU);
+       coverageThreshold, pnumThreshold, CPU, cnumOffset);
 
   cerr << '\t' << curTimer()/CLOCKS_PER_SEC << " secs" << endl;
 

--- a/cmvs_catkin/src/cmvs/bundle.cc
+++ b/cmvs_catkin/src/cmvs/bundle.cc
@@ -126,14 +126,6 @@ void Cbundle::prep2(void) {
 void Cbundle::run(const std::string prefix, const int imageThreshold,
                   const int tau, const float scoreRatioThreshold,
                   const float coverageThreshold,
-                  const int pnumThreshold, const int CPU) {
-  const unsigned int no_offset = 0u;
-  run(prefix, imageThreshold, tau, scoreRatioThreshold, coverageThreshold, pnumThreshold, CPU, no_offset);
-}
-
-void Cbundle::run(const std::string prefix, const int imageThreshold,
-                  const int tau, const float scoreRatioThreshold,
-                  const float coverageThreshold,
                   const int pnumThreshold, const int CPU, const unsigned int cnumOffset) {
   startTimer();
   
@@ -187,6 +179,14 @@ void Cbundle::run(const std::string prefix, const int imageThreshold,
   // Output results
   writeVis();
   writeGroups();
+}
+
+void Cbundle::run(const std::string prefix, const int imageThreshold,
+                  const int tau, const float scoreRatioThreshold,
+                  const float coverageThreshold,
+                  const int pnumThreshold, const int CPU) {
+  const unsigned int no_offset = 0u;
+  run(prefix, imageThreshold, tau, scoreRatioThreshold, coverageThreshold, pnumThreshold, CPU, no_offset);
 }
 
 float Cbundle::computeLink(const int image0, const int image1) {

--- a/pmvs_catkin/include/pmvs/image/photoSetS.h
+++ b/pmvs_catkin/include/pmvs/image/photoSetS.h
@@ -12,7 +12,8 @@ class CphotoSetS {
   virtual ~CphotoSetS();
 
   void init(const std::vector<int>& images, const std::string prefix,
-            const int maxLevel, const int size, const int alloc);
+            const int maxLevel, const int size, const int alloc,
+            const unsigned int cnumOffset = 0u);
   
   // grabTex given 2D sampling information
   void grabTex(const int index, const int level, const Vec2f& icoord,

--- a/pmvs_catkin/src/pmvs/image/camera.cc
+++ b/pmvs_catkin/src/pmvs/image/camera.cc
@@ -36,6 +36,7 @@ void Ccamera::init(const std::string cname, const int maxLevel) {
     m_txtType = 3;
   else {
     cerr << "Unrecognizable txt format" << endl;
+    cerr << "File name: " << cname << endl;
     exit (1);
   }
 

--- a/pmvs_catkin/src/pmvs/image/photoSetS.cc
+++ b/pmvs_catkin/src/pmvs/image/photoSetS.cc
@@ -15,10 +15,11 @@ CphotoSetS::~CphotoSetS() {
 
 
 void CphotoSetS::init(const std::vector<int>& images, const std::string prefix,
-                      const int maxLevel, const int size, const int alloc) {
+                      const int maxLevel, const int size, const int alloc,
+                      const unsigned int cnumOffset) {
   m_images = images;
   m_num = (int)images.size();
-  
+
   for (int i = 0; i < (int)images.size(); ++i)
     m_dict[images[i]] = i;
   
@@ -27,7 +28,7 @@ void CphotoSetS::init(const std::vector<int>& images, const std::string prefix,
   m_photos.resize(m_num);
   cerr << "Reading images: " << flush;
   for (int index = 0; index < m_num; ++index) {
-    const int image = m_images[index];
+    const int image = m_images[index] + cnumOffset;
 
     char test0[1024], test1[1024];
     char test2[1024], test3[1024];


### PR DESCRIPTION
Due to the incremental reconstruction, the input images and the associated camera info files are not necessarily numbered from 0 to N, but from M to M + N. In order to support this a new, optional input parameter for M was added.
