### PR TITLE
Added catkin include directory

### DIFF
--- a/pmvs_catkin/CMakeLists.txt
+++ b/pmvs_catkin/CMakeLists.txt
@@ -16,6 +16,7 @@ include_directories(${X11_INCLUDE_DIRS})
 include_directories(${Xext_INCLUDE_DIRS})
 include_directories(${BOOST_INCLUDE_DIRS})
 include_directories(${JPEG_INCLUDE_DIR})
+include_directories(${CATKIN_DEVEL_PREFIX}/include)
 
 set(BASE_PMVS base_pmvs)
 set(PMVS pmvs2)


### PR DESCRIPTION
This seems to fix the issue that multiagent_mapping isn't compiling on xenial docker slaves, as happened here http://129.132.38.183:8080/view/multiagent_mapping/job/multiagent_mapping_multiarch/label=ubuntu-xenial/1382.

Related to https://github.com/ethz-asl/nlopt/issues/8

@HannesSommer 